### PR TITLE
free: handle memory statistics more than 4GB correctly

### DIFF
--- a/crash/src/main/resources/crash/commands/cloudius/free.groovy
+++ b/crash/src/main/resources/crash/commands/cloudius/free.groovy
@@ -19,8 +19,8 @@ public class free extends OSvCommand {
       @FormatSizeOptions.Mb Boolean isMb,
       @FormatSizeOptions.Gb Boolean isGb,
       @FormatSizeOptions.Human Boolean isH) {
-    int total = Integer.parseInt(OSvAPI.get("/os/memory/total"))
-    int free  = Integer.parseInt(OSvAPI.get("/os/memory/free"))
+    long total = new BigInteger(OSvAPI.get("/os/memory/total")).longValue()
+    long free  = new BigInteger(OSvAPI.get("/os/memory/free")).longValue()
 
     def unit = SizeFormatter.toSizeUnit(isB, isKb, isMb, isGb, false, isH)
     def data = TextHelper.leftPadColumns([


### PR DESCRIPTION
Integer.parseInt only can handle 32 bit integer, so it will throw
a exception if we have memory large than 4GB.

This patch use BigInteger.longValue() to replace Integer.parseInt().

Signed-off-by: Li Yu raise.sail@gmail.com
